### PR TITLE
Install everything in /Library instead of /System/Library

### DIFF
--- a/mySIMBL/AppDelegate.m
+++ b/mySIMBL/AppDelegate.m
@@ -841,13 +841,21 @@ NSArray *tabViews;
 
 - (IBAction)toggleAMFI:(id)sender {
     SIMBLManager *sim_m = [SIMBLManager sharedInstance];
+    BOOL amfiStatus = [sim_m AMFI_enabled];
+    
     [sim_m AMFI_toggle];
+    
     NSImage *on = [NSImage imageNamed:NSImageNameStatusAvailable];
     NSImage *off = [NSImage imageNamed:NSImageNameStatusUnavailable];
-    if (_AMFIStatus.image == on)
-        [_AMFIStatus setImage:off];
-    else
-        [_AMFIStatus setImage:on];
+    
+    /* if actually toggled, change image */
+    if (!amfiStatus)
+    {
+        if (_AMFIStatus.image == on)
+            [_AMFIStatus setImage:off];
+        else
+            [_AMFIStatus setImage:on];
+    }
 }
 
 - (void)setupSIMBLview {

--- a/mySIMBL/AppDelegate.m
+++ b/mySIMBL/AppDelegate.m
@@ -8,6 +8,8 @@
 
 #import "AppDelegate.h"
 
+#define SIMBL_OSAX  @"/Library/ScriptingAdditions/SIMBL.osax"
+
 AppDelegate* myDelegate;
 
 NSMutableArray *allLocalPlugins;
@@ -799,7 +801,7 @@ NSArray *tabViews;
             agentUpdate = true;
     }
     
-    if (![[NSFileManager defaultManager] fileExistsAtPath:@"/System/Library/ScriptingAdditions/SIMBL.osax"]) {
+    if (![[NSFileManager defaultManager] fileExistsAtPath:SIMBL_OSAX]) {
         osaxUpdate = true;
     } else {
         key = [sim_m OSAX_versions];


### PR DESCRIPTION
@w0lfschild This PR originally aimed to remove the necessity to disable SIP.

Later, I realised that this doesn't fix the problem and we still need to disable SIP but with this patch we don't have to disable SIP completely, we just need to disable debugging restrictions (`csrutil enable --without debug`).

Also, this patch uses the desired approach (by apple), to install things in `/Library` and not `/System/Library`.

I also added an improvement, we now check if AMFI actually changed after we toggle it, just to make sure before changing the image from on->off etc...

Problem:  With this patch mySIMBL fails to load the plugins... I am not sure if the problem is that i don't have a developer ID to sign mySIMBL so I am making this pull request anyway.

Follow-up to #92 